### PR TITLE
Support svg files in thumbnail lookup

### DIFF
--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -22,7 +22,7 @@ export function pickThumbnailKey(keys: string[], src: string): string | null {
   const dir = src.includes("/") ? src.slice(0, src.lastIndexOf("/") + 1) : "";
   const base = src.includes("/") ? src.slice(src.lastIndexOf("/") + 1) : src;
 
-  const exts = ["png", "jpg", "jpeg", "webp", "avif"];
+  const exts = ["png", "jpg", "jpeg", "webp", "avif", "svg"];
 
   const direct = exts.map((ext) => `${dir}${base}.${ext}`);
   for (const c of direct) {

--- a/test/unit/image.spec.ts
+++ b/test/unit/image.spec.ts
@@ -22,3 +22,22 @@ test("pickThumbnailKey returns null when nothing matches", async () => {
   const keys: string[] = [];
   expect(pickThumbnailKey(keys, "blog/nope")).toBe(null);
 });
+
+test("pickThumbnailKey matches an svg when no raster format exists", async () => {
+  const keys = ["/src/assets/blog/uni/exchange.svg"];
+
+  expect(pickThumbnailKey(keys, "blog/uni/exchange")).toBe(
+    "/src/assets/blog/uni/exchange.svg"
+  );
+});
+
+test("pickThumbnailKey prefers a raster format over an svg", async () => {
+  const keys = [
+    "/src/assets/blog/uni/exchange.svg",
+    "/src/assets/blog/uni/exchange.jpg",
+  ];
+
+  expect(pickThumbnailKey(keys, "blog/uni/exchange")).toBe(
+    "/src/assets/blog/uni/exchange.jpg"
+  );
+});


### PR DESCRIPTION
Adds svg to the recognized extensions in pickThumbnailKey so SVGs can be used as thumbnails alongside raster formats.


Claude-Session: https://claude.ai/code/session_01KSQsw4PAkxWMxjAJGEzggS