### PR TITLE
Adapt sync and notify to the flattened content-repo layout.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ There is no separate lint/typecheck script; `astro build` (via `astro check` int
 
 Blog posts (`src/content/blog`) and portfolio entries (`src/content/portfolio`), plus their images (`src/assets/blog`, `src/assets/portfolio`), are **not the source of truth** in this repo for content that comes from the content repo. They get overwritten by `npm run tool:sync`, which copies from a checked-out `.content/` directory (cloned from `leo-lem/content.leolem.dev` by `.github/actions/checkout-content` in CI, or manually via `git clone` locally). `.content/` is gitignored here.
 
+In the content repo, each top-level directory mixes markdown and images together (no separate `content`/`assets` split): `portfolio/` and one directory per blog category (e.g. `engineering/`, `systems/`, `life/`, `building/`, `guest/`). `tool/sync.ts` reads those top-level directories and, for each, routes `.md` files into `src/content/<collection>/<category>/` and image files (`.png`, `.jpg`/`.jpeg`, `.avif`, `.webp`, `.gif`, `.svg`) into `src/assets/<collection>/<category>/`; any subdirectory (e.g. a project's image gallery) is copied recursively into the asset destination. `portfolio` is its own collection with no category subfolder; every other top-level directory name becomes a category folder under the `blog` collection.
+
 - `topics.json`, `about.md`, static pages (`imprint.md`, `privacy.md`) and everything under `src/pages`, `src/components`, `src/layout`, `src/lib` ARE owned by this repo.
 - When editing blog/portfolio content for real, it belongs in the content repo, not here — this repo just renders it. Local edits under `src/content/blog|portfolio` will be clobbered by the next sync.
 - `tool/sync.ts` is intentionally generic (`from`, `root`, `collections` params) so it's testable without touching the real filesystem layout — see `test/tool/sync.spec.ts`.
@@ -65,7 +67,7 @@ Standalone Node/tsx scripts, each with a `default export` function (for testing/
 
 - **`sync.ts`** — content repo → `src/` merge, see above.
 - **`icons.ts`** — generates favicons/manifest/social.png from `src/assets/profile.jpg` + `header-dark.png` using the `favicons` package, output to `public/`.
-- **`notify.ts`** — reads blog markdown directly out of `.content/content/blog` (its own lightweight frontmatter parser, not Astro's content layer, since it runs standalone), diffs against `.content/.notified.json`, and sends an OneSignal template email notification for newly-published, non-future-dated posts. Run from `main.yml`'s `notify` job after a successful deploy; commits the updated `.notified.json` back to the content repo afterward.
+- **`notify.ts`** — reads blog markdown directly out of every category directory under `.content/` (excluding `portfolio`), using its own lightweight frontmatter parser (not Astro's content layer, since it runs standalone), diffs against `.content/.notified.json`, and sends an OneSignal template email notification for newly-published, non-future-dated posts. Run from `main.yml`'s `notify` job after a successful deploy; commits the updated `.notified.json` back to the content repo afterward.
 
 ## CI (`.github/workflows`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ In the content repo, each top-level directory mixes markdown and images together
 
 - `topics.json`, `about.md`, static pages (`imprint.md`, `privacy.md`) and everything under `src/pages`, `src/components`, `src/layout`, `src/lib` ARE owned by this repo.
 - When editing blog/portfolio content for real, it belongs in the content repo, not here — this repo just renders it. Local edits under `src/content/blog|portfolio` will be clobbered by the next sync.
-- `tool/sync.ts` is intentionally generic (`from`, `root`, `collections` params) so it's testable without touching the real filesystem layout — see `test/tool/sync.spec.ts`.
+- `tool/sync.ts` is intentionally generic (`from`, `root` params) so it's testable without touching the real filesystem layout — see `test/tool/sync.spec.ts`.
 
 ## Content model (`src/content.config.ts`)
 

--- a/test/tool/notify.spec.ts
+++ b/test/tool/notify.spec.ts
@@ -15,7 +15,6 @@ type ServerCapture = {
 type TmpRepo = {
   tmpRoot: string;
   from: string;
-  blogDir: string;
   stateFile: string;
 };
 
@@ -86,37 +85,42 @@ const test = base.extend<{ capture: ServerCapture; repo: TmpRepo }>({
   repo: async ({ }, use) => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "leolem-notify-"));
     const from = path.join(tmpRoot, ".content");
-    const blogDir = path.join(from, "content", "blog");
     const stateFile = path.join(from, ".notified.json");
 
     const nowIso = new Date(Date.now() - 60_000).toISOString();
     const futureIso = new Date(Date.now() + 7 * 24 * 3_600_000).toISOString();
 
     await write(
-      path.join(blogDir, "vigil", "framework.mdx"),
+      path.join(from, "building", "vigil-framework.mdx"),
       md({ title: "Vigil Framework", short: "A thing.", date: nowIso, tags: "Vigil" })
     );
 
     await write(
-      path.join(blogDir, "balance.mdx"),
+      path.join(from, "life", "balance.mdx"),
       md({ title: "Balance", short: "Another thing.", date: nowIso, tags: "Life" })
     );
 
     await write(
-      path.join(blogDir, "scheduled.mdx"),
+      path.join(from, "life", "scheduled.mdx"),
       md({ title: "Scheduled", short: "Should not send.", date: futureIso, tags: "Future" })
     );
 
     await write(
-      path.join(blogDir, "already", "sent.mdx"),
+      path.join(from, "engineering", "already-sent.mdx"),
       md({ title: "Already", short: "Should be skipped.", date: nowIso, tags: "Skip" })
     );
 
+    // A portfolio entry should never be picked up as a blog article to notify about.
+    await write(
+      path.join(from, "portfolio", "vigil.md"),
+      md({ title: "Vigil", short: "Project.", date: nowIso, tags: "Vigil" })
+    );
+
     await fs.mkdir(path.dirname(stateFile), { recursive: true });
-    await fs.writeFile(stateFile, JSON.stringify(["already/sent"], null, 2), "utf8");
+    await fs.writeFile(stateFile, JSON.stringify(["engineering/already-sent"], null, 2), "utf8");
 
     try {
-      await use({ tmpRoot, from, blogDir, stateFile });
+      await use({ tmpRoot, from, stateFile });
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }
@@ -141,11 +145,10 @@ test("notify sends 1 template post per new article", async ({ capture, repo }) =
     capture.apiBase,
     repo.tmpRoot,
     repo.from,
-    repo.stateFile,
-    repo.blogDir
+    repo.stateFile
   );
 
-  expect(r.sent.map((a) => a.id).sort()).toEqual(["balance", "vigil/framework"]);
+  expect(r.sent.map((a) => a.id).sort()).toEqual(["building/vigil-framework", "life/balance"]);
   expect(capture.received.length).toBe(2);
 
   const bodies = capture.received as Array<Record<string, unknown>>;
@@ -160,8 +163,8 @@ test("notify sends 1 template post per new article", async ({ capture, repo }) =
     .map((b) => (b.custom_data as any)?.url as string | undefined)
     .filter((u): u is string => typeof u === "string");
 
-  expect(urls).toContain("http://localhost:4321/blog/vigil/framework/");
-  expect(urls).toContain("http://localhost:4321/blog/balance/");
+  expect(urls).toContain("http://localhost:4321/blog/building/vigil-framework/");
+  expect(urls).toContain("http://localhost:4321/blog/life/balance/");
 });
 
 test("notify skips scheduled future posts and already-notified ids", async ({ capture, repo }) => {
@@ -174,20 +177,19 @@ test("notify skips scheduled future posts and already-notified ids", async ({ ca
     capture.apiBase,
     repo.tmpRoot,
     repo.from,
-    repo.stateFile,
-    repo.blogDir
+    repo.stateFile
   );
 
-  expect(r.skippedScheduled).toEqual(["scheduled"]);
-  expect(r.skippedAlready).toEqual(["already/sent"]);
+  expect(r.skippedScheduled).toEqual(["life/scheduled"]);
+  expect(r.skippedAlready).toEqual(["engineering/already-sent"]);
 
   const bodies = capture.received as Array<Record<string, unknown>>;
   const urls = bodies
     .map((b) => (b.url as string | undefined) || ((b.custom_data as any)?.url as string | undefined))
     .filter((u): u is string => typeof u === "string");
 
-  expect(urls.some((u) => u.includes("/blog/scheduled/"))).toBe(false);
-  expect(urls.some((u) => u.includes("/blog/already/sent/"))).toBe(false);
+  expect(urls.some((u) => u.includes("/blog/life/scheduled/"))).toBe(false);
+  expect(urls.some((u) => u.includes("/blog/engineering/already-sent/"))).toBe(false);
 });
 
 test("notify writes state and is idempotent on rerun", async ({ capture, repo }) => {
@@ -200,17 +202,16 @@ test("notify writes state and is idempotent on rerun", async ({ capture, repo })
     capture.apiBase,
     repo.tmpRoot,
     repo.from,
-    repo.stateFile,
-    repo.blogDir
+    repo.stateFile
   );
 
   expect(r1.sent.length).toBe(2);
 
   const state1 = await readJson<string[]>(repo.stateFile);
-  expect(state1).toContain("already/sent");
-  expect(state1).toContain("balance");
-  expect(state1).toContain("vigil/framework");
-  expect(state1).not.toContain("scheduled");
+  expect(state1).toContain("engineering/already-sent");
+  expect(state1).toContain("life/balance");
+  expect(state1).toContain("building/vigil-framework");
+  expect(state1).not.toContain("life/scheduled");
 
   const before = capture.received.length;
 
@@ -223,8 +224,7 @@ test("notify writes state and is idempotent on rerun", async ({ capture, repo })
     capture.apiBase,
     repo.tmpRoot,
     repo.from,
-    repo.stateFile,
-    repo.blogDir
+    repo.stateFile
   );
 
   expect(r2.sent.length).toBe(0);
@@ -244,8 +244,7 @@ test("notify uses Basic auth header and JSON content-type", async ({ capture, re
     capture.apiBase,
     repo.tmpRoot,
     repo.from,
-    repo.stateFile,
-    repo.blogDir
+    repo.stateFile
   );
 
   expect(capture.headers.length).toBeGreaterThan(0);
@@ -260,7 +259,7 @@ test("notify collapses multiline short block scalars to one line", async ({ capt
   const nowIso = new Date(Date.now() - 60_000).toISOString();
 
   await write(
-    path.join(repo.blogDir, "multiline.mdx"),
+    path.join(repo.from, "systems", "multiline.mdx"),
     mdRaw(
       `title: "Multiline"
 short: |
@@ -283,16 +282,15 @@ tags: ["Systems"]`
     capture.apiBase,
     repo.tmpRoot,
     repo.from,
-    repo.stateFile,
-    repo.blogDir
+    repo.stateFile
   );
 
-  expect(r.sent.map((a) => a.id)).toContain("multiline");
+  expect(r.sent.map((a) => a.id)).toContain("systems/multiline");
 
   const bodies = capture.received as Array<Record<string, any>>;
   const matching = bodies.filter((b) => {
     const url = (b.url as string | undefined) || b.custom_data?.url;
-    return url === "http://localhost:4321/blog/multiline/";
+    return url === "http://localhost:4321/blog/systems/multiline/";
   });
 
   expect(matching.length).toBe(1);

--- a/test/tool/sync.spec.ts
+++ b/test/tool/sync.spec.ts
@@ -16,31 +16,28 @@ async function read(p: string) {
   return fs.readFile(p, "utf8");
 }
 
-test("sync copies content and assets from .content into src", async () => {
+test("sync copies blog category and portfolio content/assets from .content into src", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "leolem-sync-"));
 
   const from = path.join(tmp, ".content");
   const root = tmp;
 
-  await writeFile(
-    path.join(from, "content", "blog", "hello.md"),
-    "---\ntitle: Hello\n---\nHi\n"
-  );
-  await writeFile(
-    path.join(from, "assets", "blog", "hello.png"),
-    Buffer.from([1, 2, 3, 4])
-  );
+  await writeFile(path.join(from, "engineering", "hello.md"), "---\ntitle: Hello\n---\nHi\n");
+  await writeFile(path.join(from, "engineering", "hello.png"), Buffer.from([1, 2, 3, 4]));
 
-  await writeFile(path.join(root, "src", "content", "blog", "hello.md"), "old\n");
+  await writeFile(path.join(from, "portfolio", "sample.md"), "---\ntitle: Sample\n---\nHi\n");
+  await writeFile(path.join(from, "portfolio", "sample.png"), Buffer.from([5, 6, 7, 8]));
+  await writeFile(path.join(from, "portfolio", "sample", "1.avif"), Buffer.from([9, 9, 9]));
+
   await writeFile(
-    path.join(root, "src", "assets", "blog", "hello.png"),
-    Buffer.from([9, 9, 9])
+    path.join(root, "src", "content", "blog", "engineering", "hello.md"),
+    "old\n"
   );
 
-  await sync(from, root, ["blog"]);
+  await sync(from, root);
 
-  const mdDst = path.join(root, "src", "content", "blog", "hello.md");
-  const imgDst = path.join(root, "src", "assets", "blog", "hello.png");
+  const mdDst = path.join(root, "src", "content", "blog", "engineering", "hello.md");
+  const imgDst = path.join(root, "src", "assets", "blog", "engineering", "hello.png");
 
   const [mdStat, imgStat] = await Promise.all([fs.stat(mdDst), fs.stat(imgDst)]);
   expect(mdStat.isFile()).toBe(true);
@@ -49,24 +46,29 @@ test("sync copies content and assets from .content into src", async () => {
   const md = await read(mdDst);
   expect(md.includes("title: Hello")).toBe(true);
 
-  const [img, srcImg] = await Promise.all([
-    fs.readFile(imgDst),
-    fs.readFile(path.join(from, "assets", "blog", "hello.png")),
+  const portfolioMdDst = path.join(root, "src", "content", "portfolio", "sample.md");
+  const portfolioImgDst = path.join(root, "src", "assets", "portfolio", "sample.png");
+  const galleryDst = path.join(root, "src", "assets", "portfolio", "sample", "1.avif");
+
+  const [portfolioMdStat, portfolioImgStat, galleryStat] = await Promise.all([
+    fs.stat(portfolioMdDst),
+    fs.stat(portfolioImgDst),
+    fs.stat(galleryDst),
   ]);
-  expect(img.equals(srcImg)).toBe(true);
+  expect(portfolioMdStat.isFile()).toBe(true);
+  expect(portfolioImgStat.isFile()).toBe(true);
+  expect(galleryStat.isFile()).toBe(true);
 
   await fs.rm(tmp, { recursive: true, force: true });
 });
 
-test("sync throws when .content/content is missing", async () => {
+test("sync throws when the content directory is missing", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "leolem-sync-"));
 
   const from = path.join(tmp, ".content");
   const root = tmp;
 
-  await fs.mkdir(from, { recursive: true });
-
-  await expect(sync(from, root, ["blog"])).rejects.toThrow(/Missing content directory/);
+  await expect(sync(from, root)).rejects.toThrow(/Missing content directory/);
 
   await fs.rm(tmp, { recursive: true, force: true });
 });

--- a/test/tool/sync.spec.ts
+++ b/test/tool/sync.spec.ts
@@ -24,6 +24,7 @@ test("sync copies blog category and portfolio content/assets from .content into 
 
   await writeFile(path.join(from, "engineering", "hello.md"), "---\ntitle: Hello\n---\nHi\n");
   await writeFile(path.join(from, "engineering", "hello.png"), Buffer.from([1, 2, 3, 4]));
+  await writeFile(path.join(from, "engineering", "world.mdx"), "---\ntitle: World\n---\nHi\n");
 
   await writeFile(path.join(from, "portfolio", "sample.md"), "---\ntitle: Sample\n---\nHi\n");
   await writeFile(path.join(from, "portfolio", "sample.png"), Buffer.from([5, 6, 7, 8]));
@@ -45,6 +46,10 @@ test("sync copies blog category and portfolio content/assets from .content into 
 
   const md = await read(mdDst);
   expect(md.includes("title: Hello")).toBe(true);
+
+  const mdxDst = path.join(root, "src", "content", "blog", "engineering", "world.mdx");
+  const mdxStat = await fs.stat(mdxDst);
+  expect(mdxStat.isFile()).toBe(true);
 
   const portfolioMdDst = path.join(root, "src", "content", "portfolio", "sample.md");
   const portfolioImgDst = path.join(root, "src", "assets", "portfolio", "sample.png");

--- a/tool/notify.ts
+++ b/tool/notify.ts
@@ -65,6 +65,18 @@ async function listMarkdownFiles(dir: string): Promise<string[]> {
   return out;
 }
 
+async function listBlogMarkdownFiles(from: string): Promise<string[]> {
+  const entries = await fs.readdir(from, { withFileTypes: true });
+  const out: string[] = [];
+
+  for (const e of entries) {
+    if (!e.isDirectory() || e.name.startsWith(".") || e.name === "portfolio") continue;
+    out.push(...(await listMarkdownFiles(path.join(from, e.name))));
+  }
+
+  return out;
+}
+
 function isScheduledFuture(dateStr: string | undefined): boolean {
   if (!dateStr) return false;
   const d = new Date(dateStr);
@@ -140,21 +152,20 @@ export default async function notify(
   apiBase: string = "https://onesignal.com",
   root: string = process.cwd(),
   from: string = path.join(root, ".content"),
-  stateFile: string = path.join(from, ".notified.json"),
-  blogDir: string = path.join(from, "content", "blog")
+  stateFile: string = path.join(from, ".notified.json")
 ): Promise<{ sent: Article[]; skippedScheduled: string[]; skippedAlready: string[] }> {
   if (!appId || !apiKey || !templateId || !site)
     throw new Error("Missing env vars");
 
   const alreadyNotified = await readState(stateFile);
-  const files = await listMarkdownFiles(blogDir);
+  const files = await listBlogMarkdownFiles(from);
 
   const skippedScheduled: string[] = [];
   const skippedAlready: string[] = [];
   const toSend: Article[] = [];
 
   for (const file of files) {
-    const id = toSlug(blogDir, file);
+    const id = toSlug(from, file);
 
     if (alreadyNotified.has(id)) {
       skippedAlready.push(id);

--- a/tool/sync.ts
+++ b/tool/sync.ts
@@ -45,7 +45,7 @@ export default async function sync(
           recursive: true,
           force: true,
         });
-      } else if (item.name.endsWith(".md")) {
+      } else if (/\.mdx?$/i.test(item.name)) {
         await fs.copyFile(source, path.join(contentDestination, item.name));
       } else if (imageExtensions.has(path.extname(item.name).toLowerCase())) {
         await fs.copyFile(source, path.join(assetDestination, item.name));

--- a/tool/sync.ts
+++ b/tool/sync.ts
@@ -3,32 +3,57 @@ import path from "node:path";
 
 import { exists, isExecuted } from "./lib";
 
+const imageExtensions = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".avif",
+  ".webp",
+  ".gif",
+  ".svg",
+]);
+
 export default async function sync(
   from: string = ".content",
-  root: string = process.cwd(),
-  collections: string[] = ["blog", "portfolio"]
+  root: string = process.cwd()
 ) {
-  if (!(await exists(path.join(from, "content"))))
-    throw new Error("Missing content directory");
+  if (!(await exists(from))) throw new Error("Missing content directory");
 
-  for (const name of collections) {
-    const content = path.join(from, "content", name);
-    if (await exists(content)) {
-      const destination = path.join(root, "src", "content", name);
-      await fs.mkdir(destination, { recursive: true });
-      await fs.cp(content, destination, { recursive: true, force: true });
-    }
+  const entries = await fs.readdir(from, { withFileTypes: true });
+  const categories = entries
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+    .map((entry) => entry.name);
 
-    const asset = path.join(from, "assets", name);
-    if (await exists(asset)) {
-      const destination = path.join(root, "src", "assets", name);
-      await fs.mkdir(destination, { recursive: true });
-      await fs.cp(asset, destination, { recursive: true, force: true });
+  if (categories.length === 0) throw new Error("Missing content directory");
+
+  for (const category of categories) {
+    const collection = category === "portfolio" ? "portfolio" : "blog";
+    const sub = category === "portfolio" ? "" : category;
+
+    const contentDestination = path.join(root, "src", "content", collection, sub);
+    const assetDestination = path.join(root, "src", "assets", collection, sub);
+
+    await fs.mkdir(contentDestination, { recursive: true });
+    await fs.mkdir(assetDestination, { recursive: true });
+
+    const items = await fs.readdir(path.join(from, category), { withFileTypes: true });
+    for (const item of items) {
+      const source = path.join(from, category, item.name);
+
+      if (item.isDirectory()) {
+        await fs.cp(source, path.join(assetDestination, item.name), {
+          recursive: true,
+          force: true,
+        });
+      } else if (item.name.endsWith(".md")) {
+        await fs.copyFile(source, path.join(contentDestination, item.name));
+      } else if (imageExtensions.has(path.extname(item.name).toLowerCase())) {
+        await fs.copyFile(source, path.join(assetDestination, item.name));
+      }
     }
   }
 
-  console.log(`Merged ${collections.join(", ")} from ${from}`);
+  console.log(`Merged ${categories.join(", ")} from ${from}`);
 }
 
-if (isExecuted(import.meta.url))
-  await sync();
+if (isExecuted(import.meta.url)) await sync();


### PR DESCRIPTION
The content repo now merges assets and markdown together per category (e.g. .content/engineering/*.md + *.png) instead of separate content/ and assets/ trees. Update tool/sync.ts to route each category's files by extension, and tool/notify.ts to scan blog categories directly under .content/ instead of a now-nonexistent content/blog path.